### PR TITLE
fix: 'NoneType' object is not iterable in google

### DIFF
--- a/src/translate_shell/translators/online/google.py
+++ b/src/translate_shell/translators/online/google.py
@@ -147,6 +147,8 @@ class GoogleTranslator(OnlineTranslator):
         definition = self.get_paraphrase(resp)
         result = []
         for x in resp[5]:
+            if x[2] is None:
+                continue
             for i in x[2]:
                 if i[0] != definition:
                     result.append(i[0])


### PR DESCRIPTION
https://github.com/Freed-Wu/translate-shell/blob/b24592e3a080f770ceafc2726407513414d03578/src/translate_shell/translators/online/google.py#L150

Second index of the list "x" could contain None. That raises TypeError: 'type' object is not iterable.

STR:
`from translate_shell.translate import translate
`
`translator = translate(
                    text="sample \nstring\n\n",
                    target_lang="ru",
                    source_lang="en"
            )`
